### PR TITLE
refactor(deps): tweak redux usage and fix lot of runtime issues

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,1 +1,4 @@
-{}
+{
+  "ignore_dirs": ["node_modules", ".git"],
+  "ignore_files": [".log", ".tmp"]
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-redux": "^9.1.0",
     "react-timeago": "^7.2.0",
     "react-use": "^17.5.0",
+    "redux-thunk": "^3.1.0",
     "slugify": "^1.6.6",
     "styled-components": "6.1.8"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@photobot/reduxjs-toolkit-persist": "^7.2.2",
     "@reduxjs/toolkit": "^2.2.1",
     "color": "^4.2.3",
     "eslint-config-next": "^14",
@@ -39,6 +38,7 @@
     "react-timeago": "^7.2.0",
     "react-use": "^17.5.0",
     "redux-thunk": "^3.1.0",
+    "reduxjs-toolkit-persist": "^7.2.1",
     "slugify": "^1.6.6",
     "styled-components": "6.1.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ dependencies:
   react-use:
     specifier: ^17.5.0
     version: 17.5.0(react-dom@18.2.0)(react@18.2.0)
+  redux-thunk:
+    specifier: ^3.1.0
+    version: 3.1.0(redux@5.0.1)
   slugify:
     specifier: ^1.6.6
     version: 1.6.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ dependencies:
   '@fortawesome/react-fontawesome':
     specifier: ^0.2.0
     version: 0.2.0(@fortawesome/fontawesome-svg-core@6.5.1)(react@18.2.0)
-  '@photobot/reduxjs-toolkit-persist':
-    specifier: ^7.2.2
-    version: 7.2.2(@reduxjs/toolkit@2.2.1)
   '@reduxjs/toolkit':
     specifier: ^2.2.1
     version: 2.2.1(react-redux@9.1.0)(react@18.2.0)
@@ -56,6 +53,9 @@ dependencies:
   redux-thunk:
     specifier: ^3.1.0
     version: 3.1.0(redux@5.0.1)
+  reduxjs-toolkit-persist:
+    specifier: ^7.2.1
+    version: 7.2.1(@reduxjs/toolkit@2.2.1)
   slugify:
     specifier: ^1.6.6
     version: 1.6.6
@@ -1100,14 +1100,6 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
-
-  /@photobot/reduxjs-toolkit-persist@7.2.2(@reduxjs/toolkit@2.2.1):
-    resolution: {integrity: sha512-0SJKaSaSx4PJjlf2/hZmAMh9b43FfVVF5NDjz+ol4jxB0Gb8BcwmzKWTMJ2sZIMmhWqPVxvsMNhcc4A5SgcJew==}
-    peerDependencies:
-      '@reduxjs/toolkit': '>=1.6.1'
-    dependencies:
-      '@reduxjs/toolkit': 2.2.1(react-redux@9.1.0)(react@18.2.0)
-    dev: false
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5129,6 +5121,14 @@ packages:
 
   /redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+    dev: false
+
+  /reduxjs-toolkit-persist@7.2.1(@reduxjs/toolkit@2.2.1):
+    resolution: {integrity: sha512-1gu9Qid0qXlsM4a2D8eHx/YOwa7I0lgAXqM0KYQoX2RA+KMezkq5wkJKEMLoUkpqVuWYHRdU7auS2/jFVsR0gQ==}
+    peerDependencies:
+      '@reduxjs/toolkit': ^1.6.1
+    dependencies:
+      '@reduxjs/toolkit': 2.2.1(react-redux@9.1.0)(react@18.2.0)
     dev: false
 
   /reflect.getprototypeof@1.0.5:

--- a/src/components/chat_bubble/ActionButton.tsx
+++ b/src/components/chat_bubble/ActionButton.tsx
@@ -5,9 +5,9 @@ import { styled } from 'styled-components';
 import useAudio from '@/hooks/useAudio';
 import History from '@/components/chat_bubble/History';
 import { useAppSelector } from '@/redux/hooks';
-import { selectHasInteracted } from '@/redux/stores/runtime';
 import { cssVars } from '@/styles/theme';
-import { selectEnableSound } from '@/redux/stores/preference';
+import { selectEnableSound } from '@/redux/selectors/preference';
+import { selectHasInteracted } from '@/redux/selectors/runtime';
 
 const zIndexBase = 20;
 

--- a/src/components/chat_bubble/History.tsx
+++ b/src/components/chat_bubble/History.tsx
@@ -60,12 +60,12 @@ const UsserMessage = css`
   margin-left: 15px;
 `;
 
-const Message = styled.div<{ isUser: boolean }>`
+const Message = styled.div<{ $isUser: boolean }>`
   position: relative;
   padding: 10px;
   border-radius: 10px;
   margin: 10px 0 25px 0;
-  ${({ isUser }) => (isUser ? UsserMessage : BotMessage)}
+  ${({ $isUser: isUser }) => (isUser ? UsserMessage : BotMessage)}
 `;
 const MessageTime = styled.small`
   position: absolute;
@@ -148,7 +148,7 @@ const History = ({ onUserMessage, history, onClose }: Props) => {
           history
             .sort((a, b) => a.time.getTime() - b.time.getTime())
             .map((item, index) => (
-              <Message key={index} isUser={item.isUser}>
+              <Message key={index} $isUser={item.isUser}>
                 {item.text}
                 <br />
                 <MessageTime>

--- a/src/components/form/Button.tsx
+++ b/src/components/form/Button.tsx
@@ -12,16 +12,16 @@ type Props = {
 };
 
 const StyledButton = styled.button<{
-  background: string;
-  backgroundAlt: string;
-  textColor: string;
+  $background: string;
+  $backgroundAlt: string;
+  $textColor: string;
 }>`
   cursor: pointer;
-  background: ${(props) => props.background};
-  color: ${(props) => props.textColor};
+  background: ${(props) => props.$background};
+  color: ${(props) => props.$textColor};
   transition: background 0.1s ease-in-out;
   &:hover {
-    background: ${(props) => props.backgroundAlt};
+    background: ${(props) => props.$backgroundAlt};
   }
   &:disabled {
     filter: grayscale(100%);
@@ -58,9 +58,9 @@ const Button = ({ variant, children, onClick, disabled, ...rest }: Props) => {
 
   return (
     <StyledButton
-      background={color.background}
-      backgroundAlt={color.backgroundAlt}
-      textColor={color.textColor}
+      $background={color.background}
+      $backgroundAlt={color.backgroundAlt}
+      $textColor={color.textColor}
       onClick={onClick}
       disabled={disabled}
       {...rest}>

--- a/src/components/master/CookieConsent.tsx
+++ b/src/components/master/CookieConsent.tsx
@@ -2,11 +2,9 @@ import Link from 'next/link';
 import { styled } from 'styled-components';
 
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
-import {
-  selectReviewCompleted,
-  setReviewCompleted,
-} from '@/redux/stores/consent';
+import { setReviewCompleted } from '@/redux/slices/consent';
 import { cssVars, ThemeProps } from '@/styles/theme';
+import { selectReviewCompleted } from '@/redux/selectors/consent';
 
 const Wrap = styled.div<{ theme: ThemeProps }>`
   position: sticky;

--- a/src/components/master/CookieConsent.tsx
+++ b/src/components/master/CookieConsent.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { styled } from 'styled-components';
 
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
-import { setReviewCompleted } from '@/redux/slices/consent';
+import { actions as consentActions } from '@/redux/slices/consent';
 import { cssVars, ThemeProps } from '@/styles/theme';
 import { selectReviewCompleted } from '@/redux/selectors/consent';
 
@@ -28,7 +28,7 @@ const CookieBar = () => {
   const completed = useAppSelector(selectReviewCompleted);
 
   const close = () => {
-    dispatch(setReviewCompleted(true));
+    dispatch(consentActions.setReviewCompleted(true));
   };
 
   return (

--- a/src/components/master/DarkModeToggle.tsx
+++ b/src/components/master/DarkModeToggle.tsx
@@ -1,8 +1,9 @@
 import { styled } from 'styled-components';
 
-import { selectDarkMode, setDarkMode } from '@/redux/stores/preference';
+import { setDarkMode } from '@/redux/slices/preference';
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
 import { cssVars } from '@/styles/theme';
+import { selectDarkMode } from '@/redux/selectors/preference';
 
 type Props = {
   className?: string;

--- a/src/components/master/DarkModeToggle.tsx
+++ b/src/components/master/DarkModeToggle.tsx
@@ -17,7 +17,7 @@ const SelectorOption = styled.span`
 `;
 const InDarkMode = styled(SelectorOption)``;
 const InDayMode = styled(SelectorOption)``;
-const Toggler = styled.div<{ isDarkMode: boolean }>`
+const Toggler = styled.div<{ $isDarkMode: boolean }>`
   position: relative;
   display: flex;
   justify-content: space-between;
@@ -34,7 +34,7 @@ const Toggler = styled.div<{ isDarkMode: boolean }>`
     height: 100%;
     border-radius: 10px;
     transition: all 0.1s ease-in-out;
-    transform: translateX(${(props) => (props.isDarkMode ? '0' : '100%')});
+    transform: translateX(${(props) => (props.$isDarkMode ? '0' : '100%')});
   }
 `;
 
@@ -50,7 +50,7 @@ const DarkModeToggle = ({ className }: Props) => {
     <Toggler
       className={className}
       onClick={toggleDarkMode}
-      isDarkMode={isDarkMode}>
+      $isDarkMode={isDarkMode}>
       <InDayMode role="img" aria-label="sun">
         ☀️
       </InDayMode>

--- a/src/components/master/DarkModeToggle.tsx
+++ b/src/components/master/DarkModeToggle.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components';
 
-import { setDarkMode } from '@/redux/slices/preference';
+import { actions as preferenceActions } from '@/redux/slices/preference';
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
 import { cssVars } from '@/styles/theme';
 import { selectDarkMode } from '@/redux/selectors/preference';
@@ -43,7 +43,7 @@ const DarkModeToggle = ({ className }: Props) => {
   const isDarkMode = useAppSelector(selectDarkMode);
 
   const toggleDarkMode = () => {
-    dispatch(setDarkMode(!isDarkMode));
+    dispatch(preferenceActions.setDarkMode(!isDarkMode));
   };
 
   return (

--- a/src/components/master/Provider.tsx
+++ b/src/components/master/Provider.tsx
@@ -10,12 +10,12 @@ import {
   LightTheme,
   LightThemeStyle,
 } from '@/styles/theme';
-import { selectDarkMode } from '@/redux/stores/preference';
 import * as redux from '@/redux/store';
 import registerIcons from '@/utils/icons';
 import useFirstInteraction from '@/hooks/useFirstInteraction';
 import useInFocusMeter from '@/hooks/useInFocusMeter';
-import { selectExitPrompt } from '@/redux/stores/experience';
+import { selectDarkMode } from '@/redux/selectors/preference';
+import { selectExitPrompt } from '@/redux/selectors/experience';
 
 type Props = {
   children: React.ReactNode;

--- a/src/components/master/Provider.tsx
+++ b/src/components/master/Provider.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { ThemeProvider } from 'styled-components';
 import { useBeforeUnload } from 'react-use';
 import { Provider as ReduxProvider } from 'react-redux';
-import { PersistGate } from '@photobot/reduxjs-toolkit-persist/lib/integration/react';
+import { PersistGate } from 'reduxjs-toolkit-persist/integration/react';
 
 import {
   DarkTheme,

--- a/src/components/navigation/Marquee.tsx
+++ b/src/components/navigation/Marquee.tsx
@@ -32,11 +32,11 @@ const Wrap = styled.div`
     overflow: hidden;
   }
 `;
-const Anchor = styled(Link)<{ highlight: boolean; flashing: boolean }>`
+const Anchor = styled(Link)<{ $highlight: boolean; $flashing: boolean }>`
   margin: 0 2rem;
   display: inline-block;
   color: ${cssVars.color.background};
-  animation-name: ${({ highlight, flashing }) =>
+  animation-name: ${({ $highlight: highlight, $flashing: flashing }) =>
     highlight ? (flashing ? flashingAnim : highlightAnim) : ''};
   animation-duration: 1s;
   animation-iteration-count: infinite;
@@ -66,8 +66,8 @@ const Marquee = ({ className }: Props) => {
               href={path}
               key={index}
               passHref
-              highlight
-              flashing={flashing}>
+              $highlight
+              $flashing={flashing}>
               {title}
             </Anchor>
           );

--- a/src/components/navigation/Marquee.tsx
+++ b/src/components/navigation/Marquee.tsx
@@ -4,9 +4,9 @@ import MarqueePlugin from 'react-fast-marquee';
 import { styled, keyframes } from 'styled-components';
 
 import { useAppSelector } from '@/redux/hooks';
-import { selectEnableFlashing } from '@/redux/stores/preference';
 import ArticleService from '@/services/ArticleService';
 import { cssVars } from '@/styles/theme';
+import { selectEnableFlashing } from '@/redux/selectors/preference';
 
 type Props = {
   className?: string;

--- a/src/components/tricks/LockedContent.tsx
+++ b/src/components/tricks/LockedContent.tsx
@@ -5,17 +5,17 @@ import { cssVars } from '@/styles/theme';
 
 import EscapingElement from './EscapingElement';
 
-const Wrap = styled.div<{ maxHeight: number | string }>`
+const Wrap = styled.div<{ $maxHeight: number | string }>`
   position: relative;
-  max-height: ${({ maxHeight }) =>
+  max-height: ${({ $maxHeight: maxHeight }) =>
     typeof maxHeight === 'string' ? maxHeight : `${maxHeight || 0}px`};
   transition: max-height 0.3s ease-in-out;
   overflow: hidden;
 `;
-const Overlay = styled.div<{ isHidden: boolean }>`
+const Overlay = styled.div<{ $isHidden: boolean }>`
   position: absolute;
-  bottom: ${({ isHidden }) => (isHidden ? -500 : 0)}px;
-  opacity: ${({ isHidden }) => (isHidden ? 0 : 1)};
+  bottom: ${({ $isHidden: isHidden }) => (isHidden ? -500 : 0)}px;
+  opacity: ${({ $isHidden: isHidden }) => (isHidden ? 0 : 1)};
   left: 0;
   width: 100%;
   background: ${cssVars.color.surface};
@@ -67,9 +67,9 @@ const LockedContent = ({
   };
 
   return (
-    <Wrap maxHeight={active ? maxHeight : 'auto'}>
+    <Wrap $maxHeight={active ? maxHeight : 'auto'}>
       <div ref={contentRef}>{children}</div>
-      <Overlay isHidden={!active || isRevealed}>
+      <Overlay $isHidden={!active || isRevealed}>
         <h1>
           You gott pay a $0.69/hour with 24 months of commitment in order to see
           the next paragraph.

--- a/src/components/wheel_of_fortune/AnimatedWheel.tsx
+++ b/src/components/wheel_of_fortune/AnimatedWheel.tsx
@@ -37,7 +37,7 @@ const Wrap = styled.div`
   max-height: 500px;
   padding: 2rem;
 `;
-const PointerWrap = styled.div<{ wiggle: boolean }>`
+const PointerWrap = styled.div<{ $wiggle: boolean }>`
   position: absolute;
   top: 0;
   right: calc(50% - 15px);
@@ -50,7 +50,7 @@ const PointerWrap = styled.div<{ wiggle: boolean }>`
     top: 13px;
     right: calc(50% - 9px);
   }
-  ${({ wiggle }) =>
+  ${({ $wiggle: wiggle }) =>
     wiggle &&
     css`
       animation: ${PointerWiggle} 0.2s linear infinite;
@@ -79,18 +79,18 @@ const WheelAnimationWrap = styled.div`
   border-radius: 50%;
 `;
 const WheelAnimation = styled.div<{
-  duration: number;
-  rotation: number;
-  allowFlashing: boolean;
+  $duration: number;
+  $rotation: number;
+  $allowFlashing: boolean;
 }>`
-  transform: rotate(${(props) => `${props.rotation}deg`});
-  transition: transform ${(props) => `${props.duration}s`}
+  transform: rotate(${(props) => `${props.$rotation}deg`});
+  transition: transform ${(props) => `${props.$duration}s`}
     cubic-bezier(0.33, 1, 0.68, 1);
   user-select: none;
   .slice-winner {
     animation: ${SliceFlashing} 500ms infinite;
     ${(props) =>
-      !props.allowFlashing &&
+      !props.$allowFlashing &&
       css`
         animation: none;
       `}
@@ -171,7 +171,7 @@ const AnimatedWheel = ({
 
   return (
     <Wrap>
-      <PointerWrap wiggle={state === 'spinning'}>
+      <PointerWrap $wiggle={state === 'spinning'}>
         <FontAwesomeIcon icon={['fas', 'map-marker-alt']} />
       </PointerWrap>
       <CtaButton
@@ -182,9 +182,9 @@ const AnimatedWheel = ({
       </CtaButton>
       <WheelAnimationWrap ref={rotatorRef}>
         <WheelAnimation
-          duration={anim.duration}
-          rotation={anim.rotation}
-          allowFlashing={flashing}>
+          $duration={anim.duration}
+          $rotation={anim.rotation}
+          $allowFlashing={flashing}>
           <Wheel
             items={items}
             highlightIndex={state === 'completed' ? winIndex : undefined}

--- a/src/components/wheel_of_fortune/ModalContent.tsx
+++ b/src/components/wheel_of_fortune/ModalContent.tsx
@@ -4,9 +4,9 @@ import Confetti from 'react-confetti';
 import { styled } from 'styled-components';
 
 import { getWeightedRandom } from '@/utils/math';
-import { selectEnableFlashing } from '@/redux/stores/preference';
 import { useAppSelector } from '@/redux/hooks';
 import { cssVars } from '@/styles/theme';
+import { selectEnableFlashing } from '@/redux/selectors/preference';
 
 import AnimatedWheel, { AnimatedWheelState } from './AnimatedWheel';
 import { Item } from './Wheel';

--- a/src/hooks/useFirstInteraction.ts
+++ b/src/hooks/useFirstInteraction.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { PersistedStoreType } from '@/redux/store';
-import { setHasInteracted } from '@/redux/slices/runtime';
+import { actions as runtimeActions } from '@/redux/slices/runtime';
 
 /**
  * Some browsers will limit features until the first user interaction has
@@ -13,7 +13,7 @@ const useFirstInteraction = (store: PersistedStoreType) => {
   const handleInteraction = useCallback(() => {
     if (completed) return;
     setCompleted(true);
-    store.dispatch(setHasInteracted());
+    store.dispatch(runtimeActions.setHasInteracted());
   }, [completed, store]);
 
   useEffect(() => {

--- a/src/hooks/useFirstInteraction.ts
+++ b/src/hooks/useFirstInteraction.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { PersistedStoreType } from '@/redux/store';
-import { setHasInteracted } from '@/redux/stores/runtime';
+import { setHasInteracted } from '@/redux/slices/runtime';
 
 /**
  * Some browsers will limit features until the first user interaction has

--- a/src/hooks/useInFocusMeter.ts
+++ b/src/hooks/useInFocusMeter.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { PersistedStoreType } from '@/redux/store';
-import { setInFocusSeconds, setIsInFocus } from '@/redux/stores/runtime';
+import { setInFocusSeconds, setIsInFocus } from '@/redux/slices/runtime';
 
 /**
  * This will mesaure how long the webpage has been in focus and report it to

--- a/src/hooks/useInFocusMeter.ts
+++ b/src/hooks/useInFocusMeter.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { PersistedStoreType } from '@/redux/store';
-import { setInFocusSeconds, setIsInFocus } from '@/redux/slices/runtime';
+import { actions as runtimeActions } from '@/redux/slices/runtime';
 
 /**
  * This will mesaure how long the webpage has been in focus and report it to
@@ -24,7 +24,7 @@ const useInFocusMeter = (store: PersistedStoreType) => {
   }, []);
 
   useEffect(() => {
-    store.dispatch(setIsInFocus(isInFocus));
+    store.dispatch(runtimeActions.setIsInFocus(isInFocus));
   }, [isInFocus, store]);
 
   useEffect(() => {
@@ -36,7 +36,7 @@ const useInFocusMeter = (store: PersistedStoreType) => {
       // TODO: Broadcasting this will force the whole screen to rerender
       // which is unacceptable. Try solve this or even move runtime stuff
       // into a separate store, hook.
-      store.dispatch(setInFocusSeconds(elapsed + 1));
+      store.dispatch(runtimeActions.setInFocusSeconds(elapsed + 1));
       setElapsed(elapsed + 1);
     }, 1000);
     return () => clearInterval(interval);

--- a/src/pages/articles/[slug].tsx
+++ b/src/pages/articles/[slug].tsx
@@ -3,9 +3,9 @@ import Error from 'next/error';
 import Head from 'next/head';
 
 import { useAppSelector } from '@/redux/hooks';
-import { selectContentPaywall } from '@/redux/stores/experience';
 import LockedContent from '@/components/tricks/LockedContent';
 import ArticleService from '@/services/ArticleService';
+import { selectContentPaywall } from '@/redux/selectors/experience';
 
 interface Props {
   slug: string;

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -28,27 +28,27 @@ export default function PrivacyPolicy() {
         In order for us to provide you the best possible experience on our
         websites, we need to collect and process certain information. Depending
         on your use of the Services, that may include:
-        <ul>
-          <li>
-            <strong>Usage data</strong> — when you visit our site, we will
-            store: the website from which you visited us from, the parts of our
-            site you visit, the date and duration of your visit, your anonymised
-            IP address, information from the device (device type, operating
-            system, screen resolution, language, country you are located in, and
-            web browser type) you used during your visit, and more. We process
-            this usage data in Matomo Analytics for statistical purposes, to
-            improve our site and to recognize and stop any misuse.
-          </li>
-          <li>
-            <strong>Cookies</strong> — we use cookies (small data files
-            transferred onto computers or devices by sites) for record-keeping
-            purposes and to enhance functionality on our site. You may
-            deactivate or restrict the transmission of cookies by changing the
-            settings of your web browser. Cookies that are already stored may be
-            deleted at any time.
-          </li>
-        </ul>
       </p>
+      <ul>
+        <li>
+          <strong>Usage data</strong> — when you visit our site, we will store:
+          the website from which you visited us from, the parts of our site you
+          visit, the date and duration of your visit, your anonymised IP
+          address, information from the device (device type, operating system,
+          screen resolution, language, country you are located in, and web
+          browser type) you used during your visit, and more. We process this
+          usage data in Matomo Analytics for statistical purposes, to improve
+          our site and to recognize and stop any misuse.
+        </li>
+        <li>
+          <strong>Cookies</strong> — we use cookies (small data files
+          transferred onto computers or devices by sites) for record-keeping
+          purposes and to enhance functionality on our site. You may deactivate
+          or restrict the transmission of cookies by changing the settings of
+          your web browser. Cookies that are already stored may be deleted at
+          any time.
+        </li>
+      </ul>
       <h3>Your Rights</h3>
       <p>
         You have the right to be informed of Personal Data processed by The MAW,

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -9,19 +9,19 @@ import {
   setEnableFlashing,
   setEnableSound,
   setAdultFilter,
-} from '@/redux/stores/preference';
+} from '@/redux/slices/preference';
 import {
   setAllowLocation,
   setAllowNotification,
   setAllowAnalytics,
   setAllowCookies,
-} from '@/redux/stores/consent';
+} from '@/redux/slices/consent';
 import {
   setContentPaywall,
   setExitPrompt,
   setMockChat,
   setWheelOfFortune,
-} from '@/redux/stores/experience';
+} from '@/redux/slices/experience';
 
 const Blocks = styled.div`
   display: grid;

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -29,10 +29,10 @@ const BlockTitle = styled.h2`
   margin: 0 0 ${cssVars.spacing.gap2x} 0;
   font-size: ${cssVars.fontSize.headline};
 `;
-const BlockBody = styled.div<{ gap?: boolean }>`
+const BlockBody = styled.div<{ $gap?: boolean }>`
   display: flex;
   flex-direction: column;
-  gap: ${(props) => (props.gap ? cssVars.spacing.gap : 0)};
+  gap: ${(props) => (props.$gap ? cssVars.spacing.gap : 0)};
 `;
 const RowWithLabel = styled.div`
   label {
@@ -103,7 +103,7 @@ export default function PrivacyPolicy() {
       <Blocks>
         <Block>
           <BlockTitle>Preferences</BlockTitle>
-          <BlockBody gap>
+          <BlockBody $gap>
             <ToggableRow
               label="Dark mode"
               name="dark_mode"
@@ -133,7 +133,7 @@ export default function PrivacyPolicy() {
 
         <Block>
           <BlockTitle>Consent</BlockTitle>
-          <BlockBody gap>
+          <BlockBody $gap>
             <ToggableRow
               label="Allow non-essential cookies"
               name="allow_cookies"
@@ -157,7 +157,7 @@ export default function PrivacyPolicy() {
 
         <Block>
           <BlockTitle>Experience</BlockTitle>
-          <BlockBody gap>
+          <BlockBody $gap>
             <ToggableRow
               label="Mock chat"
               name="mock_chat"

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -13,7 +13,6 @@ import {
 import {
   setAllowLocation,
   setAllowNotification,
-  setAllowAnalytics,
   setAllowCookies,
 } from '@/redux/slices/consent';
 import {
@@ -81,6 +80,30 @@ export default function PrivacyPolicy() {
   const consent = useAppSelector((state) => state.consent);
   const runtime = useAppSelector((state) => state.runtime);
 
+  // Preferences
+  const onDarkModeChange = () => dispatch(setDarkMode(!preference.isDarkMode));
+  const onFlashingContentsChange = () =>
+    dispatch(setEnableFlashing(!preference.enableFlashing));
+  const onSoundChange = () => dispatch(setEnableSound(!preference.enableSound));
+  const onAdultFilterChange = () =>
+    dispatch(setAdultFilter(!preference.adultFilter));
+  // Consent block
+  const onAllowCookiesChange = () =>
+    dispatch(setAllowCookies(!consent.allowCookies));
+  const onAlowNotificationChange = () =>
+    dispatch(setAllowNotification(!consent.allowNotification));
+  const onAllowLocationChange = () =>
+    dispatch(setAllowLocation(!consent.allowLocation));
+  // Experience block
+  const onAlowMockChatChange = () =>
+    dispatch(setMockChat(!experience.mockChat));
+  const onWheelOfFortuneChange = () =>
+    dispatch(setWheelOfFortune(!experience.wheelOfFortune));
+  const onExitPromptChange = () =>
+    dispatch(setExitPrompt(!experience.exitPrompt));
+  const onContentPaywallChange = () =>
+    dispatch(setContentPaywall(!experience.contentPaywall));
+
   return (
     <main>
       <h1>Settings</h1>
@@ -93,27 +116,25 @@ export default function PrivacyPolicy() {
               label="Dark mode"
               name="dark_mode"
               checked={preference.isDarkMode}
-              onChange={() => dispatch(setDarkMode(!preference.isDarkMode))}
+              onChange={onDarkModeChange}
             />
             <ToggableRow
               label="Flashing contents"
               name="enable_flashing"
               checked={preference.enableFlashing}
-              onChange={() =>
-                dispatch(setEnableFlashing(!preference.enableFlashing))
-              }
+              onChange={onFlashingContentsChange}
             />
             <ToggableRow
               label="Sound"
               name="enable_sound"
               checked={preference.enableSound}
-              onChange={() => dispatch(setEnableSound(!preference.enableSound))}
+              onChange={onSoundChange}
             />
             <ToggableRow
               label="Filter adult contents"
-              name="enable_flashing"
+              name="adult_filter"
               checked={preference.adultFilter}
-              onChange={() => dispatch(setAdultFilter(!preference.adultFilter))}
+              onChange={onAdultFilterChange}
             />
           </BlockBody>
         </Block>
@@ -125,31 +146,19 @@ export default function PrivacyPolicy() {
               label="Allow non-essential cookies"
               name="allow_cookies"
               checked={consent.allowCookies}
-              onChange={() => dispatch(setAllowCookies(!consent.allowCookies))}
-            />
-            <ToggableRow
-              label="Allow analytics"
-              name="allow_analytics"
-              checked={consent.allowAnalytics}
-              onChange={() =>
-                dispatch(setAllowAnalytics(!consent.allowAnalytics))
-              }
+              onChange={onAllowCookiesChange}
             />
             <ToggableRow
               label="Allow notification"
               name="allow_notification"
               checked={consent.allowNotification || false}
-              onChange={() =>
-                dispatch(setAllowNotification(!consent.allowNotification))
-              }
+              onChange={onAlowNotificationChange}
             />
             <ToggableRow
               label="Allow location"
               name="enable_location"
               checked={consent.allowLocation || false}
-              onChange={() =>
-                dispatch(setAllowLocation(!consent.allowLocation))
-              }
+              onChange={onAllowLocationChange}
             />
           </BlockBody>
         </Block>
@@ -161,29 +170,25 @@ export default function PrivacyPolicy() {
               label="Mock chat"
               name="mock_chat"
               checked={experience.mockChat}
-              onChange={() => dispatch(setMockChat(!experience.mockChat))}
+              onChange={onAlowMockChatChange}
             />
             <ToggableRow
               label="Wheel of fortune"
               name="wheel_of_fortune"
               checked={experience.wheelOfFortune}
-              onChange={() =>
-                dispatch(setWheelOfFortune(!experience.wheelOfFortune))
-              }
+              onChange={onWheelOfFortuneChange}
             />
             <ToggableRow
               label="Exit prompt"
               name="exit_prompt"
               checked={experience.exitPrompt}
-              onChange={() => dispatch(setExitPrompt(!experience.exitPrompt))}
+              onChange={onExitPromptChange}
             />
             <ToggableRow
               label="Content paywall"
               name="content_paywall"
               checked={experience.contentPaywall}
-              onChange={() =>
-                dispatch(setContentPaywall(!experience.contentPaywall))
-              }
+              onChange={onContentPaywallChange}
             />
           </BlockBody>
         </Block>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -4,23 +4,13 @@ import { ChangeEventHandler } from 'react';
 
 import { cssRule, cssVars } from '@/styles/theme';
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
-import {
-  setDarkMode,
-  setEnableFlashing,
-  setEnableSound,
-  setAdultFilter,
-} from '@/redux/slices/preference';
-import {
-  setAllowLocation,
-  setAllowNotification,
-  setAllowCookies,
-} from '@/redux/slices/consent';
-import {
-  setContentPaywall,
-  setExitPrompt,
-  setMockChat,
-  setWheelOfFortune,
-} from '@/redux/slices/experience';
+import { actions as preferenceActions } from '@/redux/slices/preference';
+import { actions as consentActions } from '@/redux/slices/consent';
+import { actions as experienceActions } from '@/redux/slices/experience';
+import selectPreference from '@/redux/selectors/preference';
+import selectExperience from '@/redux/selectors/experience';
+import selectConsent from '@/redux/selectors/consent';
+import selectRuntime from '@/redux/selectors/runtime';
 
 const Blocks = styled.div`
   display: grid;
@@ -75,34 +65,36 @@ const ToggableRow = ({ label, name, checked, onChange }: ToggableRowProps) => {
 
 export default function PrivacyPolicy() {
   const dispatch = useAppDispatch();
-  const preference = useAppSelector((state) => state.preference);
-  const experience = useAppSelector((state) => state.experience);
-  const consent = useAppSelector((state) => state.consent);
-  const runtime = useAppSelector((state) => state.runtime);
+  const preference = useAppSelector(selectPreference);
+  const experience = useAppSelector(selectExperience);
+  const consent = useAppSelector(selectConsent);
+  const runtime = useAppSelector(selectRuntime);
 
   // Preferences
-  const onDarkModeChange = () => dispatch(setDarkMode(!preference.isDarkMode));
+  const onDarkModeChange = () =>
+    dispatch(preferenceActions.setDarkMode(!preference.isDarkMode));
   const onFlashingContentsChange = () =>
-    dispatch(setEnableFlashing(!preference.enableFlashing));
-  const onSoundChange = () => dispatch(setEnableSound(!preference.enableSound));
+    dispatch(preferenceActions.setEnableFlashing(!preference.enableFlashing));
+  const onSoundChange = () =>
+    dispatch(preferenceActions.setEnableSound(!preference.enableSound));
   const onAdultFilterChange = () =>
-    dispatch(setAdultFilter(!preference.adultFilter));
+    dispatch(preferenceActions.setAdultFilter(!preference.adultFilter));
   // Consent block
   const onAllowCookiesChange = () =>
-    dispatch(setAllowCookies(!consent.allowCookies));
+    dispatch(consentActions.setAllowCookies(!consent.allowCookies));
   const onAlowNotificationChange = () =>
-    dispatch(setAllowNotification(!consent.allowNotification));
+    dispatch(consentActions.setAllowNotification(!consent.allowNotification));
   const onAllowLocationChange = () =>
-    dispatch(setAllowLocation(!consent.allowLocation));
+    dispatch(consentActions.setAllowLocation(!consent.allowLocation));
   // Experience block
   const onAlowMockChatChange = () =>
-    dispatch(setMockChat(!experience.mockChat));
+    dispatch(experienceActions.setMockChat(!experience.mockChat));
   const onWheelOfFortuneChange = () =>
-    dispatch(setWheelOfFortune(!experience.wheelOfFortune));
+    dispatch(experienceActions.setWheelOfFortune(!experience.wheelOfFortune));
   const onExitPromptChange = () =>
-    dispatch(setExitPrompt(!experience.exitPrompt));
+    dispatch(experienceActions.setExitPrompt(!experience.exitPrompt));
   const onContentPaywallChange = () =>
-    dispatch(setContentPaywall(!experience.contentPaywall));
+    dispatch(experienceActions.setContentPaywall(!experience.contentPaywall));
 
   return (
     <main>

--- a/src/redux/hooks.ts
+++ b/src/redux/hooks.ts
@@ -1,7 +1,7 @@
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 
-import type { AppDispatch, AppState } from './store';
+import type { AppDispatch, AppRootState } from './store';
 
 export const useAppDispatch = () => useDispatch<AppDispatch>();
 
-export const useAppSelector: TypedUseSelectorHook<AppState> = useSelector;
+export const useAppSelector: TypedUseSelectorHook<AppRootState> = useSelector;

--- a/src/redux/selectors/consent.ts
+++ b/src/redux/selectors/consent.ts
@@ -1,0 +1,15 @@
+import type { AppState } from '@/redux/store';
+
+const selectConsent = (state: AppState) => state.consent;
+export const selectReviewCompleted = (state: AppState) =>
+  state.consent.reviewCompleted;
+export const selectAllowCookies = (state: AppState) =>
+  state.consent.allowCookies;
+export const selectAllowAnalytics = (state: AppState) =>
+  state.consent.allowAnalytics;
+export const selectAllowLocation = (state: AppState) =>
+  state.consent.allowLocation;
+export const selectAllowNotification = (state: AppState) =>
+  state.consent.allowNotification;
+
+export default selectConsent;

--- a/src/redux/selectors/consent.ts
+++ b/src/redux/selectors/consent.ts
@@ -5,8 +5,6 @@ export const selectReviewCompleted = (state: AppState) =>
   state.consent.reviewCompleted;
 export const selectAllowCookies = (state: AppState) =>
   state.consent.allowCookies;
-export const selectAllowAnalytics = (state: AppState) =>
-  state.consent.allowAnalytics;
 export const selectAllowLocation = (state: AppState) =>
   state.consent.allowLocation;
 export const selectAllowNotification = (state: AppState) =>

--- a/src/redux/selectors/consent.ts
+++ b/src/redux/selectors/consent.ts
@@ -1,13 +1,13 @@
-import type { AppState } from '@/redux/store';
+import type { AppRootState } from '@/redux/store';
 
-const selectConsent = (state: AppState) => state.consent;
-export const selectReviewCompleted = (state: AppState) =>
+const selectConsent = (state: AppRootState) => state.consent;
+export const selectReviewCompleted = (state: AppRootState) =>
   state.consent.reviewCompleted;
-export const selectAllowCookies = (state: AppState) =>
+export const selectAllowCookies = (state: AppRootState) =>
   state.consent.allowCookies;
-export const selectAllowLocation = (state: AppState) =>
+export const selectAllowLocation = (state: AppRootState) =>
   state.consent.allowLocation;
-export const selectAllowNotification = (state: AppState) =>
+export const selectAllowNotification = (state: AppRootState) =>
   state.consent.allowNotification;
 
 export default selectConsent;

--- a/src/redux/selectors/experience.ts
+++ b/src/redux/selectors/experience.ts
@@ -1,0 +1,12 @@
+import type { AppState } from '@/redux/store';
+
+const selectExperience = (state: AppState) => state.experience;
+export const selectMockChat = (state: AppState) => state.experience.mockChat;
+export const selectWheelOfFortune = (state: AppState) =>
+  state.experience.wheelOfFortune;
+export const selectExitPrompt = (state: AppState) =>
+  state.experience.exitPrompt;
+export const selectContentPaywall = (state: AppState) =>
+  state.experience.contentPaywall;
+
+export default selectExperience;

--- a/src/redux/selectors/experience.ts
+++ b/src/redux/selectors/experience.ts
@@ -1,12 +1,13 @@
-import type { AppState } from '@/redux/store';
+import type { AppRootState } from '@/redux/store';
 
-const selectExperience = (state: AppState) => state.experience;
-export const selectMockChat = (state: AppState) => state.experience.mockChat;
-export const selectWheelOfFortune = (state: AppState) =>
+const selectExperience = (state: AppRootState) => state.experience;
+export const selectMockChat = (state: AppRootState) =>
+  state.experience.mockChat;
+export const selectWheelOfFortune = (state: AppRootState) =>
   state.experience.wheelOfFortune;
-export const selectExitPrompt = (state: AppState) =>
+export const selectExitPrompt = (state: AppRootState) =>
   state.experience.exitPrompt;
-export const selectContentPaywall = (state: AppState) =>
+export const selectContentPaywall = (state: AppRootState) =>
   state.experience.contentPaywall;
 
 export default selectExperience;

--- a/src/redux/selectors/preference.ts
+++ b/src/redux/selectors/preference.ts
@@ -1,0 +1,12 @@
+import type { AppState } from '@/redux/store';
+
+const selectPreference = (state: AppState) => state.preference;
+export const selectDarkMode = (state: AppState) => state.preference.isDarkMode;
+export const selectEnableSound = (state: AppState) =>
+  state.preference.enableSound;
+export const selectEnableFlashing = (state: AppState) =>
+  state.preference.enableFlashing;
+export const selectAdultFilter = (state: AppState) =>
+  state.preference.adultFilter;
+
+export default selectPreference;

--- a/src/redux/selectors/preference.ts
+++ b/src/redux/selectors/preference.ts
@@ -1,12 +1,13 @@
-import type { AppState } from '@/redux/store';
+import type { AppRootState } from '@/redux/store';
 
-const selectPreference = (state: AppState) => state.preference;
-export const selectDarkMode = (state: AppState) => state.preference.isDarkMode;
-export const selectEnableSound = (state: AppState) =>
+const selectPreference = (state: AppRootState) => state.preference;
+export const selectDarkMode = (state: AppRootState) =>
+  state.preference.isDarkMode;
+export const selectEnableSound = (state: AppRootState) =>
   state.preference.enableSound;
-export const selectEnableFlashing = (state: AppState) =>
+export const selectEnableFlashing = (state: AppRootState) =>
   state.preference.enableFlashing;
-export const selectAdultFilter = (state: AppState) =>
+export const selectAdultFilter = (state: AppRootState) =>
   state.preference.adultFilter;
 
 export default selectPreference;

--- a/src/redux/selectors/runtime.ts
+++ b/src/redux/selectors/runtime.ts
@@ -1,12 +1,12 @@
-import type { AppState } from '@/redux/store';
+import type { AppRootState } from '@/redux/store';
 
-const selectRuntime = (state: AppState) => state.runtime;
-export const selectStartTime = (state: AppState) =>
+const selectRuntime = (state: AppRootState) => state.runtime;
+export const selectStartTime = (state: AppRootState) =>
   new Date(state.runtime.startTime);
-export const selectIsInFocus = (state: AppState) => state.runtime.isInFocus;
-export const selectHasInteracted = (state: AppState) =>
+export const selectIsInFocus = (state: AppRootState) => state.runtime.isInFocus;
+export const selectHasInteracted = (state: AppRootState) =>
   state.runtime.hasInteracted;
-export const selectInFocusSeconds = (state: AppState) =>
+export const selectInFocusSeconds = (state: AppRootState) =>
   state.runtime.inFocusSeconds;
 
 export default selectRuntime;

--- a/src/redux/selectors/runtime.ts
+++ b/src/redux/selectors/runtime.ts
@@ -1,0 +1,12 @@
+import type { AppState } from '@/redux/store';
+
+const selectRuntime = (state: AppState) => state.runtime;
+export const selectStartTime = (state: AppState) =>
+  new Date(state.runtime.startTime);
+export const selectIsInFocus = (state: AppState) => state.runtime.isInFocus;
+export const selectHasInteracted = (state: AppState) =>
+  state.runtime.hasInteracted;
+export const selectInFocusSeconds = (state: AppState) =>
+  state.runtime.inFocusSeconds;
+
+export default selectRuntime;

--- a/src/redux/slices/consent.ts
+++ b/src/redux/slices/consent.ts
@@ -3,7 +3,6 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 export interface ConsentState {
   reviewCompleted: boolean;
   allowCookies: boolean;
-  allowAnalytics: boolean;
   allowLocation: boolean | null;
   allowNotification: boolean | null;
 }
@@ -11,7 +10,6 @@ export interface ConsentState {
 const initialState: ConsentState = {
   reviewCompleted: false,
   allowCookies: true,
-  allowAnalytics: true,
   allowLocation: null,
   allowNotification: null,
 };
@@ -26,9 +24,6 @@ export const consent = createSlice({
     setAllowCookies: (state, action: PayloadAction<boolean>) => {
       state.allowCookies = action.payload;
     },
-    setAllowAnalytics: (state, action: PayloadAction<boolean>) => {
-      state.allowAnalytics = action.payload;
-    },
     setAllowLocation: (state, action: PayloadAction<boolean>) => {
       state.allowLocation = action.payload;
     },
@@ -41,7 +36,6 @@ export const consent = createSlice({
 export const {
   setReviewCompleted,
   setAllowCookies,
-  setAllowAnalytics,
   setAllowLocation,
   setAllowNotification,
 } = consent.actions;

--- a/src/redux/slices/consent.ts
+++ b/src/redux/slices/consent.ts
@@ -14,7 +14,7 @@ const initialState: ConsentState = {
   allowNotification: null,
 };
 
-export const consent = createSlice({
+export const consentSlice = createSlice({
   name: 'consent',
   initialState,
   reducers: {
@@ -33,11 +33,5 @@ export const consent = createSlice({
   },
 });
 
-export const {
-  setReviewCompleted,
-  setAllowCookies,
-  setAllowLocation,
-  setAllowNotification,
-} = consent.actions;
-
-export default consent.reducer;
+export const actions = consentSlice.actions;
+export default consentSlice.reducer;

--- a/src/redux/slices/consent.ts
+++ b/src/redux/slices/consent.ts
@@ -1,7 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import type { AppState } from '@/redux/store';
-
 export interface ConsentState {
   reviewCompleted: boolean;
   allowCookies: boolean;
@@ -47,16 +45,5 @@ export const {
   setAllowLocation,
   setAllowNotification,
 } = consent.actions;
-
-export const selectReviewCompleted = (state: AppState) =>
-  state.consent.reviewCompleted;
-export const selectAllowCookies = (state: AppState) =>
-  state.consent.allowCookies;
-export const selectAllowAnalytics = (state: AppState) =>
-  state.consent.allowAnalytics;
-export const selectAllowLocation = (state: AppState) =>
-  state.consent.allowLocation;
-export const selectAllowNotification = (state: AppState) =>
-  state.consent.allowNotification;
 
 export default consent.reducer;

--- a/src/redux/slices/experience.ts
+++ b/src/redux/slices/experience.ts
@@ -14,7 +14,7 @@ const initialState: ExperienceState = {
   contentPaywall: true,
 };
 
-export const experience = createSlice({
+export const experienceSlice = createSlice({
   name: 'experience',
   initialState,
   reducers: {
@@ -33,11 +33,5 @@ export const experience = createSlice({
   },
 });
 
-export const {
-  setMockChat,
-  setWheelOfFortune,
-  setExitPrompt,
-  setContentPaywall,
-} = experience.actions;
-
-export default experience.reducer;
+export const actions = experienceSlice.actions;
+export default experienceSlice.reducer;

--- a/src/redux/slices/experience.ts
+++ b/src/redux/slices/experience.ts
@@ -1,7 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import type { AppState } from '@/redux/store';
-
 export interface ExperienceState {
   mockChat: boolean;
   wheelOfFortune: boolean;
@@ -41,13 +39,5 @@ export const {
   setExitPrompt,
   setContentPaywall,
 } = experience.actions;
-
-export const selectMockChat = (state: AppState) => state.experience.mockChat;
-export const selectWheelOfFortune = (state: AppState) =>
-  state.experience.wheelOfFortune;
-export const selectExitPrompt = (state: AppState) =>
-  state.experience.exitPrompt;
-export const selectContentPaywall = (state: AppState) =>
-  state.experience.contentPaywall;
 
 export default experience.reducer;

--- a/src/redux/slices/preference.ts
+++ b/src/redux/slices/preference.ts
@@ -14,7 +14,7 @@ const initialState: PreferenceState = {
   adultFilter: true,
 };
 
-export const preference = createSlice({
+export const preferenceSlice = createSlice({
   name: 'preference',
   initialState,
   reducers: {
@@ -33,11 +33,5 @@ export const preference = createSlice({
   },
 });
 
-export const {
-  setDarkMode,
-  setEnableSound,
-  setEnableFlashing,
-  setAdultFilter,
-} = preference.actions;
-
-export default preference.reducer;
+export const actions = preferenceSlice.actions;
+export default preferenceSlice.reducer;

--- a/src/redux/slices/preference.ts
+++ b/src/redux/slices/preference.ts
@@ -1,7 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import type { AppState } from '@/redux/store';
-
 export interface PreferenceState {
   isDarkMode: boolean;
   enableSound: boolean;
@@ -41,13 +39,5 @@ export const {
   setEnableFlashing,
   setAdultFilter,
 } = preference.actions;
-
-export const selectDarkMode = (state: AppState) => state.preference.isDarkMode;
-export const selectEnableSound = (state: AppState) =>
-  state.preference.enableSound;
-export const selectEnableFlashing = (state: AppState) =>
-  state.preference.enableFlashing;
-export const selectAdultFilter = (state: AppState) =>
-  state.preference.adultFilter;
 
 export default preference.reducer;

--- a/src/redux/slices/runtime.ts
+++ b/src/redux/slices/runtime.ts
@@ -1,7 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-import type { AppState } from '@/redux/store';
-
 export interface RuntimeState {
   startTime: string;
   isInFocus: boolean;
@@ -38,13 +36,5 @@ export const runtime = createSlice({
 
 export const { setIsInFocus, setHasInteracted, setInFocusSeconds } =
   runtime.actions;
-
-export const selectStartTime = (state: AppState) =>
-  new Date(state.runtime.startTime);
-export const selectIsInFocus = (state: AppState) => state.runtime.isInFocus;
-export const selectHasInteracted = (state: AppState) =>
-  state.runtime.hasInteracted;
-export const selectInFocusSeconds = (state: AppState) =>
-  state.runtime.inFocusSeconds;
 
 export default runtime.reducer;

--- a/src/redux/slices/runtime.ts
+++ b/src/redux/slices/runtime.ts
@@ -18,7 +18,7 @@ const initialState: RuntimeState = {
  * Runtime stores everyting that won't get persisted. This also includes some
  * non-persional statistics.
  */
-export const runtime = createSlice({
+export const runtimeSlice = createSlice({
   name: 'runtime',
   initialState,
   reducers: {
@@ -34,7 +34,5 @@ export const runtime = createSlice({
   },
 });
 
-export const { setIsInFocus, setHasInteracted, setInFocusSeconds } =
-  runtime.actions;
-
-export default runtime.reducer;
+export const actions = runtimeSlice.actions;
+export default runtimeSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,30 +1,32 @@
-import {
-  ThunkAction,
-  Action,
-  combineReducers,
-  configureStore,
-} from '@reduxjs/toolkit';
-import storage from '@photobot/reduxjs-toolkit-persist/lib/storage';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import {
   persistReducer,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
   persistStore,
-} from '@photobot/reduxjs-toolkit-persist/lib';
-import { type PersistConfig } from '@photobot/reduxjs-toolkit-persist/src/types';
-import autoMergeLevel2 from '@photobot/reduxjs-toolkit-persist/lib/stateReconciler/autoMergeLevel2';
+} from 'reduxjs-toolkit-persist';
+import storage from 'reduxjs-toolkit-persist/lib/storage';
+import autoMergeLevel2 from 'reduxjs-toolkit-persist/lib/stateReconciler/autoMergeLevel2';
+import { type PersistConfig } from 'reduxjs-toolkit-persist/lib/types';
 
 import preferenceReducer from '@/redux/slices/preference';
 import consentReducer from '@/redux/slices/consent';
 import experienceReducer from '@/redux/slices/experience';
 import runtimeReducer from '@/redux/slices/runtime';
 
-export const rootReducer = combineReducers({
-  preference: preferenceReducer,
-  consent: consentReducer,
-  experience: experienceReducer,
-  runtime: runtimeReducer,
-});
+// Types are a bit odd with persitance store 🤔
+type RootReducerType = typeof rootReducers;
+type RootReducerReturnType = ReturnType<typeof rootReducers>;
 
-const persistConfig: PersistConfig<RootState> = {
+export type PersistedStoreType = typeof store;
+export type AppRootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
+
+const persistConfig: PersistConfig<RootReducerReturnType> = {
   version: 2,
   key: 'root',
   storage,
@@ -34,19 +36,28 @@ const persistConfig: PersistConfig<RootState> = {
   stateReconciler: autoMergeLevel2,
 };
 
-const persistedReducer = persistReducer(persistConfig, rootReducer);
-export const store = configureStore({
-  reducer: persistedReducer,
+export const rootReducers = combineReducers({
+  preference: preferenceReducer,
+  consent: consentReducer,
+  experience: experienceReducer,
+  runtime: runtimeReducer,
 });
-export const persistor = persistStore(store);
 
-export type PersistedStoreType = typeof store;
-export type RootState = ReturnType<typeof rootReducer>;
-export type AppState = ReturnType<typeof store.getState>;
-export type AppDispatch = typeof store.dispatch;
-export type AppThunk<ReturnType = void> = ThunkAction<
-  ReturnType,
-  AppState,
-  unknown,
-  Action<string>
->;
+const _persistedReducer = persistReducer(
+  persistConfig,
+  rootReducers,
+) as RootReducerType;
+
+export const store = configureStore({
+  reducer: _persistedReducer,
+  devTools: process.env.NODE_ENV !== 'production',
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+      },
+      thunk: undefined,
+    }),
+});
+
+export const persistor = persistStore(store);

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -12,10 +12,10 @@ import {
 import { type PersistConfig } from '@photobot/reduxjs-toolkit-persist/src/types';
 import autoMergeLevel2 from '@photobot/reduxjs-toolkit-persist/lib/stateReconciler/autoMergeLevel2';
 
-import preferenceReducer from '@/redux/stores/preference';
-import consentReducer from '@/redux/stores/consent';
-import experienceReducer from '@/redux/stores/experience';
-import runtimeReducer from '@/redux/stores/runtime';
+import preferenceReducer from '@/redux/slices/preference';
+import consentReducer from '@/redux/slices/consent';
+import experienceReducer from '@/redux/slices/experience';
+import runtimeReducer from '@/redux/slices/runtime';
 
 export const rootReducer = combineReducers({
   preference: preferenceReducer,


### PR DESCRIPTION
### Goal

The app had various runtime issues and wasn't quite compatible with the previous way of persisting data, the aim with this PR is to eliminate those issues and also fix common runtime errors too.

### What's included?

- Add redux-thunk
- Add reduxjs-toolkit-persist and remove @photobot/reduxjs-toolkit-persist
- Fix transient props for styled-component (errors appearing when trying to render booleans in html, adding $ prefix solved the issues)
- Splitting selectors into their respective files
- Remove analytics flag from state