### PR TITLE
fix(runtime): focus meter to use visibilitychange api

### DIFF
--- a/src/redux/slices/runtime.ts
+++ b/src/redux/slices/runtime.ts
@@ -31,6 +31,9 @@ export const runtimeSlice = createSlice({
     setInFocusSeconds: (state, action: PayloadAction<number>) => {
       state.inFocusSeconds = action.payload;
     },
+    incrementInFocusSeconds: (state) => {
+      state.inFocusSeconds += 1;
+    },
   },
 });
 


### PR DESCRIPTION
## Description

Moving away from `document.focus` and `document.blur` listeners in favor of `useInFocusMeter.ts` ([~96.61% support](https://caniuse.com/mdn-api_document_visibilitychange_event)).

Also making some necessary tweaks on state management.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation, if necessary.
- [x] I have added appropriate test cases, if applicable.
- [x] I have run the automated tests successfully.
