### PR TITLE
feat(newsletter): add fake newsletter modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ The main idea is to gather the most annoying features of modern websites in one 
 <details>
   <summary>TODO / Planned</summary>
 
-  - [ ] Newsletter modal that appears when the user leaves the screen or scrolls down a bit
   - [ ] Request for location permission (don’t worry, the website won’t use your location)
   - [ ] Sticky video player that obscures page visibility (with audio)
   - [ ] Create a captcha where you need to select all the images with a car on it but none of the images have a car on them and captcha fails
@@ -21,6 +20,7 @@ The main idea is to gather the most annoying features of modern websites in one 
 <details>
   <summary>Completed</summary>
 
+  - [x] Newsletter modal that appears when the user leaves the screen or scrolls down a bit
   - [x] Fake search page that:
     - [x] Silly recommended searches
     - [x] Doesn’t actually work or return any results

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -79,7 +79,39 @@
       "😜 YES YOU 😱",
       "📣 COME BACK 🏃"
     ],
-    "exitPrompt": "I'd reconsider leaving before some bad things happend to you. Are you sure?"
+    "exitPrompt": "I'd reconsider leaving before some bad things happend to you. Are you sure?",
+    "newsletter": {
+      "modal": {
+        "title": "Join our newsletter!",
+        "description": "Our premium newsletter brings an insane amount of value right to your inbox. Don't miss out on insights that make a real difference!",
+        "placeholder": "Enter your email",
+        "initial_confirm": "Subscribe",
+        "initial_cancel": "Don't Subscribe",
+        "use_form_actions": "Please use the relevant button instead",
+        "confirmations": [
+          {
+            "text": "We're disappointed to see that you may not have had enough time to fully consider this important and challenging decision.",
+            "confirm": "I thought about it, I still want to",
+            "cancel": "You are right, cancel"
+          },
+          {
+            "text": "We are sorry to see you subscribing, can we treat you with the joys of not being a subscriber at all?",
+            "confirm": "No thanks",
+            "cancel": "I need my treat!"
+          },
+          {
+            "text": "Have you considered skipping this newsletter?",
+            "confirm": "No",
+            "cancel": "Yes"
+          },
+          {
+            "text": "Subscribing to this newsletter might have adverse side effects. Are you still in?",
+            "confirm": "I accept side effects",
+            "cancel": "Get me out of here"
+          }
+        ]
+      }
+    }
   },
   "validation": {
     "errors": {

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -21,6 +21,7 @@
       "deadPixel": "Dead pixel",
       "exitPrompt": "Exit prompt",
       "mockChat": "Mock chat",
+      "newsletterModal": "Newsletter modal",
       "pageTitleInactiveArrayPaged": "Alternative title when tab is inactive",
       "searchDelay": "Fake search delay",
       "wheelOfFortune": "Wheel of fortune"

--- a/src/components/molecules/Modal.tsx
+++ b/src/components/molecules/Modal.tsx
@@ -7,7 +7,7 @@ import Icon from '@/components/atoms/Icon';
 
 export type ModalProps = DimmerOverlayProps & {
   title: string;
-  actions: React.ReactNode;
+  actions?: React.ReactNode;
 };
 
 const Modal: FunctionComponent<ModalProps> = ({

--- a/src/features/content_limiter/components/PartitionalLockedContent.tsx
+++ b/src/features/content_limiter/components/PartitionalLockedContent.tsx
@@ -29,7 +29,7 @@ const PartitionalLockedContent: FunctionComponent<
   const { t } = useTranslation(['content_limiter']);
   const [maxHeight, setMaxHeight] = useState(initialMaxHeight);
   const [isRevealed, setRevealed] = useState(false);
-  const [isCtaReverse, setCtaReverse] = useState(true);
+  const [flipActions, setFlipActions] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
 
   // Extends the max-height of the content until there's content to reveal
@@ -57,7 +57,7 @@ const PartitionalLockedContent: FunctionComponent<
         variant="primary"
         key="cta"
         size="sm"
-        onMouseEnter={() => setCtaReverse((prev) => !prev)}>
+        onMouseEnter={() => setFlipActions((prev) => !prev)}>
         {t('content_limiter:partitional.cta')}*
       </Button>,
       <Button
@@ -69,7 +69,7 @@ const PartitionalLockedContent: FunctionComponent<
       </Button>,
     ];
 
-    return <>{isCtaReverse ? buttons : buttons.reverse()}</>;
+    return <>{flipActions ? buttons : buttons.reverse()}</>;
   };
 
   return (

--- a/src/features/newsletter/NewsletterModalExperienceHost.tsx
+++ b/src/features/newsletter/NewsletterModalExperienceHost.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { FunctionComponent, useEffect, useState } from 'react';
+
+import NewsletterModal from './components/NewsletterModal';
+
+import useScrollDistanceTrigger from '@/hooks/useScrollDistanceTrigger';
+import { useRuntimeStore } from '@/state/runtime';
+
+export type NewsletterModalExperienceHostProps = {
+  scrollDistanceTrigger?: number;
+};
+const NewsletterModalExperienceHost: FunctionComponent<
+  NewsletterModalExperienceHostProps
+> = ({ scrollDistanceTrigger = 450 }) => {
+  const runtime = useRuntimeStore();
+  const [modalVisible, setModalVisible] = useState(false);
+
+  useScrollDistanceTrigger({
+    threshold: scrollDistanceTrigger,
+    onTrigger: () => setModalVisible(true),
+  });
+
+  useEffect(() => {
+    if (!runtime.document.isVisible) {
+      setModalVisible(true);
+    }
+  }, [runtime.document.isVisible]);
+
+  const onModalDismiss = () => {
+    setModalVisible(false);
+  };
+
+  return (
+    <>
+      {modalVisible && (
+        <NewsletterModal visible={modalVisible} onDismiss={onModalDismiss} />
+      )}
+    </>
+  );
+};
+
+export default NewsletterModalExperienceHost;

--- a/src/features/newsletter/components/NewsletterModal.tsx
+++ b/src/features/newsletter/components/NewsletterModal.tsx
@@ -1,0 +1,110 @@
+import { useTranslation } from 'next-i18next';
+import { FunctionComponent, useMemo, useState } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+import Button from '@/components/atoms/Button';
+import FormFieldError from '@/components/atoms/FormFieldError';
+import TextInput from '@/components/atoms/TextInput';
+import Modal from '@/components/molecules/Modal';
+import { type NewsletterFormInputs } from '@/features/newsletter';
+import { random } from '@/utils/math';
+import { EMAIL_PATTERN } from '@/utils/validator';
+
+type NewsletterModalProps = {
+  visible?: boolean;
+  onDismiss?: () => void;
+};
+
+const NewsletterModal: FunctionComponent<NewsletterModalProps> = ({
+  visible = false,
+  onDismiss,
+}) => {
+  const { t } = useTranslation();
+  const [flipActions, setFlipActions] = useState(false);
+  const [actions, setActions] = useState({
+    confirm: t('experiences.newsletter.modal.initial_confirm'),
+    cancel: t('experiences.newsletter.modal.initial_cancel'),
+  } as ConfirmItem satisfies ConfirmItem);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<NewsletterFormInputs>();
+
+  const confirmPool = useMemo(
+    () =>
+      t('experiences.newsletter.modal.confirmations', {
+        returnObjects: true,
+        defaultValue: [],
+      }) as ConfirmItem[],
+    [t],
+  );
+
+  const renderActions = () => {
+    const buttons = [
+      <Button key="cancel" variant="secondary" onClick={onDismiss}>
+        {actions.cancel}
+      </Button>,
+      <Button key="confirm" onClick={randomConfirmation} disabled={!isValid}>
+        {actions.confirm}
+      </Button>,
+    ];
+
+    return <>{flipActions ? buttons : buttons.reverse()}</>;
+  };
+
+  const onSubmit: SubmitHandler<NewsletterFormInputs> = (_data) => {
+    alert(t('experiences.newsletter.modal.use_form_actions'));
+  };
+
+  const randomConfirmation = () => {
+    const rnd = Math.floor(Math.random() * confirmPool.length);
+    setActions(confirmPool[rnd]);
+    setFlipActions(random(0, 1) === 0);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      title={t('experiences.newsletter.modal.title')}
+      onClose={onDismiss}
+      actions={<div className="flex gap-3">{renderActions()}</div>}>
+      <form
+        className="max-w-screen-sm"
+        method="post"
+        onSubmit={handleSubmit(onSubmit)}>
+        {actions.text && <p className="mb-4">{actions.text}</p>}
+        {!actions.text && (
+          <>
+            <p className="mb-4">
+              {t('experiences.newsletter.modal.description')}
+            </p>
+            <TextInput
+              placeholder={t('experiences.newsletter.modal.placeholder')}
+              size="lg"
+              type="email"
+              className="w-full"
+              required
+              {...register('email', {
+                required: t('validation.errors.required'),
+                pattern: {
+                  value: EMAIL_PATTERN,
+                  message: t('validation.errors.emailInvalid'),
+                },
+              })}
+            />
+            <FormFieldError error={errors.email} />
+          </>
+        )}
+      </form>
+    </Modal>
+  );
+};
+
+type ConfirmItem = {
+  text?: string;
+  confirm: string;
+  cancel: string;
+};
+
+export default NewsletterModal;

--- a/src/features/newsletter/index.ts
+++ b/src/features/newsletter/index.ts
@@ -1,0 +1,2 @@
+export { type NewsletterFormInputs } from './types';
+export { default as NewsletterModalExperienceHost } from './NewsletterModalExperienceHost';

--- a/src/features/newsletter/types.ts
+++ b/src/features/newsletter/types.ts
@@ -1,0 +1,3 @@
+export type NewsletterFormInputs = {
+  email: string;
+};

--- a/src/features/notification/NotificationPermissionExperienceHost.tsx
+++ b/src/features/notification/NotificationPermissionExperienceHost.tsx
@@ -8,12 +8,12 @@ import useScrollDistanceTrigger from '@/hooks/useScrollDistanceTrigger';
 import { useUserGrantsStore } from '@/state/user_grants';
 import { getNotificationPermissionState } from '@/utils/permission';
 
-export type NotificationPermissionExperienceProps = {
+export type NotificationPermissionExperienceHostProps = {
   scrollDistanceTrigger?: number;
 };
 const NotificationPermissionExperienceHost: FunctionComponent<
-  NotificationPermissionExperienceProps
-> = ({ scrollDistanceTrigger = 200 }) => {
+  NotificationPermissionExperienceHostProps
+> = ({ scrollDistanceTrigger = 400 }) => {
   const initialState = useRef(getNotificationPermissionState()).current;
   useScrollDistanceTrigger({
     threshold: scrollDistanceTrigger,

--- a/src/features/settings/components/ExperienceSettings.tsx
+++ b/src/features/settings/components/ExperienceSettings.tsx
@@ -11,15 +11,6 @@ const ExperienceSettings: FunctionComponent = () => {
   const { t } = useTranslation(['settings', 'common']);
   const experience = useExperienceFlagsStore();
 
-  // Experience flags
-  const onContentPaywallChange = (value: boolean) =>
-    experience.setContentPaywall(value);
-  const onDeadPixelChange = (value: boolean) => experience.setDeadPixel(value);
-  const onExitPromptChange = (value: boolean) =>
-    experience.setExitPrompt(value);
-  const onMockChatChange = (value: boolean) => experience.setMockChat(value);
-  const onWheelOfFortuneChange = (value: boolean) =>
-    experience.setWheelOfFortune(value);
   const onPageTitleInactiveArrayPagedChange = (value: boolean) =>
     experience.setPageTitle({ inactiveArrayPaged: value });
 
@@ -30,14 +21,14 @@ const ExperienceSettings: FunctionComponent = () => {
         <FormCheckbox
           name="content_paywall"
           checked={experience.contentPaywall}
-          onValueChange={onContentPaywallChange}
+          onValueChange={experience.setContentPaywall}
         />
       </SettingsBlockRow>
       <SettingsBlockRow label={t('settings:section.experienceFlags.deadPixel')}>
         <FormCheckbox
           name="dead_pixel"
           checked={experience.deadPixel}
-          onValueChange={onDeadPixelChange}
+          onValueChange={experience.setDeadPixel}
         />
       </SettingsBlockRow>
       <SettingsBlockRow
@@ -45,14 +36,22 @@ const ExperienceSettings: FunctionComponent = () => {
         <FormCheckbox
           name="exit_prompt"
           checked={experience.exitPrompt}
-          onValueChange={onExitPromptChange}
+          onValueChange={experience.setExitPrompt}
         />
       </SettingsBlockRow>
       <SettingsBlockRow label={t('settings:section.experienceFlags.mockChat')}>
         <FormCheckbox
           name="mock_chat"
           checked={experience.mockChat}
-          onValueChange={onMockChatChange}
+          onValueChange={experience.setMockChat}
+        />
+      </SettingsBlockRow>
+      <SettingsBlockRow
+        label={t('settings:section.experienceFlags.newsletterModal')}>
+        <FormCheckbox
+          name="mock_chat"
+          checked={experience.newsletterModal}
+          onValueChange={experience.setNewsletterModal}
         />
       </SettingsBlockRow>
       <SettingsBlockRow
@@ -78,7 +77,7 @@ const ExperienceSettings: FunctionComponent = () => {
         <FormCheckbox
           name="wheel_of_fortune"
           checked={experience.wheelOfFortune}
-          onValueChange={onWheelOfFortuneChange}
+          onValueChange={experience.setWheelOfFortune}
         />
       </SettingsBlockRow>
     </SettingsBlock>

--- a/src/hooks/useScrollDistanceTrigger.ts
+++ b/src/hooks/useScrollDistanceTrigger.ts
@@ -2,11 +2,13 @@ import { useCallback, useEffect, useState } from 'react';
 
 export type ConditionalTriggerProps = {
   threshold: number;
+  resetable?: boolean;
   onTrigger?: () => void;
 };
 const useScrollDistanceTrigger = ({
   threshold,
   onTrigger,
+  resetable,
 }: ConditionalTriggerProps) => {
   const [isCompleted, setCompleted] = useState(false);
 
@@ -14,8 +16,10 @@ const useScrollDistanceTrigger = ({
     if (window.scrollY >= threshold) {
       setCompleted(true);
       onTrigger?.();
+    } else if (resetable) {
+      setCompleted(false);
     }
-  }, [onTrigger, threshold]);
+  }, [onTrigger, resetable, threshold]);
 
   useEffect(() => {
     if (isCompleted) {

--- a/src/pages/user/login.tsx
+++ b/src/pages/user/login.tsx
@@ -12,6 +12,7 @@ import SiteTitle from '@/components/atoms/SiteTitle';
 import TextInput from '@/components/atoms/TextInput';
 import { LoginFormInputs } from '@/features/auth';
 import { makeI18nStaticProps } from '@/utils/i18n';
+import { EMAIL_PATTERN } from '@/utils/validator';
 
 const Login: NextPage = () => {
   const { t } = useTranslation('common');
@@ -41,6 +42,10 @@ const Login: NextPage = () => {
               className="w-full"
               {...register('email', {
                 required: t('validation.errors.required'),
+                pattern: {
+                  value: EMAIL_PATTERN,
+                  message: t('validation.errors.emailInvalid'),
+                },
               })}
             />
           </label>

--- a/src/pages/user/password-reminder.tsx
+++ b/src/pages/user/password-reminder.tsx
@@ -16,6 +16,7 @@ import TextInput from '@/components/atoms/TextInput';
 import CaptchaTitlePuzzleField from '@/components/molecules/CaptchaTitlePuzzleFied';
 import { PasswordReminderFormInputs } from '@/features/auth';
 import { makeI18nStaticProps } from '@/utils/i18n';
+import { EMAIL_PATTERN } from '@/utils/validator';
 
 const PasswordReminder: NextPage = () => {
   const { t } = useTranslation('common');
@@ -46,6 +47,10 @@ const PasswordReminder: NextPage = () => {
               className="w-full"
               {...register('email', {
                 required: t('validation.errors.required'),
+                pattern: {
+                  value: EMAIL_PATTERN,
+                  message: t('validation.errors.emailInvalid'),
+                },
               })}
             />
           </label>

--- a/src/pages/user/registration.tsx
+++ b/src/pages/user/registration.tsx
@@ -19,6 +19,7 @@ import {
   RegistrationFormInputs,
 } from '@/features/auth';
 import { makeI18nStaticProps } from '@/utils/i18n';
+import { EMAIL_PATTERN } from '@/utils/validator';
 
 const Registration: NextPage = () => {
   const { t } = useTranslation('common');
@@ -107,6 +108,10 @@ const Registration: NextPage = () => {
                 className="w-full"
                 {...register('email', {
                   required: t('validation.errors.required'),
+                  pattern: {
+                    value: EMAIL_PATTERN,
+                    message: t('validation.errors.emailInvalid'),
+                  },
                 })}
               />
             </label>

--- a/src/providers/ExperienceProvider.tsx
+++ b/src/providers/ExperienceProvider.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'next-i18next';
 import { FunctionComponent, PropsWithChildren } from 'react';
 import { useBeforeUnload } from 'react-use';
 
+import { NewsletterModalExperienceHost } from '@/features/newsletter';
 import { NotificationPermissionExperienceHost } from '@/features/notification';
 import { PageTitleExperienceHost } from '@/features/page_title';
 import useDocumentVisibilityListener from '@/hooks/useDocumentVisibilityListener';
@@ -11,7 +12,7 @@ import { useExperienceFlagsStore } from '@/state/experience_flags';
 const ExperienceProvider: FunctionComponent<PropsWithChildren> = ({
   children,
 }) => {
-  const exitPrompt = useExperienceFlagsStore((state) => state.exitPrompt);
+  const { exitPrompt, newsletterModal } = useExperienceFlagsStore();
   const { t } = useTranslation('common');
 
   useFirstInteractionListener();
@@ -23,6 +24,7 @@ const ExperienceProvider: FunctionComponent<PropsWithChildren> = ({
     <>
       <PageTitleExperienceHost />
       <NotificationPermissionExperienceHost />
+      {newsletterModal && <NewsletterModalExperienceHost />}
       {children}
     </>
   );

--- a/src/state/experience_flags.ts
+++ b/src/state/experience_flags.ts
@@ -6,6 +6,7 @@ export interface ExperienceFlagsState {
   deadPixel: boolean;
   exitPrompt: boolean;
   mockChat: boolean;
+  newsletterModal: boolean;
   pageTitle: {
     inactiveArrayPaged: boolean;
     inactiveMarquee: boolean;
@@ -20,6 +21,7 @@ export interface ExperienceFlagsStateActions {
   setDeadPixel: (deadPixel: boolean) => void;
   setExitPrompt: (exitPrompt: boolean) => void;
   setMockChat: (mockChat: boolean) => void;
+  setNewsletterModal: (newsletterModal: boolean) => void;
   setPageTitle: (pageTitle: Partial<ExperienceFlagsState['pageTitle']>) => void;
   setSearchDelay: (searchDelay: boolean) => void;
   setWheelOfFortune: (wheelOfFortune: boolean) => void;
@@ -34,6 +36,7 @@ const initialState: ExperienceFlagsState = {
   deadPixel: true,
   exitPrompt: true,
   mockChat: true,
+  newsletterModal: true,
   pageTitle: {
     // `inactiveMarquee` and `randomGlitch` are not enabled because title refresh rate is to low
     // maybe these can be turned on at a later point.
@@ -53,6 +56,7 @@ export const useExperienceFlagsStore = create(
       setDeadPixel: (deadPixel) => set({ deadPixel }),
       setExitPrompt: (exitPrompt) => set({ exitPrompt }),
       setMockChat: (mockChat) => set({ mockChat }),
+      setNewsletterModal: (newsletterModal) => set({ newsletterModal }),
       setPageTitle: (pageTitle) =>
         set((state) => ({
           pageTitle: {
@@ -66,12 +70,12 @@ export const useExperienceFlagsStore = create(
     {
       name: 'zustand-experience-flags-storage',
       storage: createJSONStorage(() => localStorage),
-      version: 3,
+      version: 4,
       migrate: (persistedState, _version) => {
         // Versions are supersets atm
         return {
           ...(persistedState as ExperienceFlagsStore),
-          version: 3,
+          version: 4,
         };
       },
     },

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,0 +1,3 @@
+// https://emailregex.com/index.html
+export const EMAIL_PATTERN =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;


### PR DESCRIPTION
## Description

Introducing new newsletter modal that activates once you starts to scroll down and also when the page gets inactive.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation, if necessary.
- [x] I have added appropriate test cases, if applicable.
- [x] I have run the automated tests successfully.

## Screenshots

<img width="836" alt="image" src="https://github.com/user-attachments/assets/493c7b34-4ac4-4eb8-92ce-bbeb54cebfce">
