### PR TITLE
feat(sticky-video): add sticky video player experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ The main idea is to gather the most annoying features of modern websites in one 
   <summary>TODO / Planned</summary>
 
   - [ ] Request for location permission (don’t worry, the website won’t use your location)
-  - [ ] Sticky video player that obscures page visibility (with audio)
   - [ ] Create a captcha where you need to select all the images with a car on it but none of the images have a car on them and captcha fails
   - [ ] Low-quality images
   - [ ] Age verification on certain images
@@ -20,6 +19,7 @@ The main idea is to gather the most annoying features of modern websites in one 
 <details>
   <summary>Completed</summary>
 
+  - [x] Sticky video player that obscures page visibility
   - [x] Newsletter modal that appears when the user leaves the screen or scrolls down a bit
   - [x] Fake search page that:
     - [x] Silly recommended searches

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -37,6 +37,7 @@
     "title": "Share this page",
     "description": "Spread the misery! Be sure to inflict this painfully obnoxious website on your friends too — why suffer alone when you can drag them down with you?"
   },
+  "cookieConsent": "This website uses cookies to ensure you get the best experience on our website. It's also a joke so many of the features are buggy or doens't even work on purpose. You can customize your experience and cookie settings in the settings menu.",
   "themeSwitch": {
     "label": "Switch theme",
     "darkMode": "Dark mode",

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -25,7 +25,8 @@
       "notifications": "Notifications",
       "pageTitleInactiveArrayPaged": "Alternative title when tab is inactive",
       "searchDelay": "Fake search delay",
-      "wheelOfFortune": "Wheel of fortune"
+      "wheelOfFortune": "Wheel of fortune",
+      "stickyVideo": "Sticky video"
     },
     "runtime": {
       "title": "About this session",

--- a/src/components/organisms/CookieConsent.tsx
+++ b/src/components/organisms/CookieConsent.tsx
@@ -16,13 +16,8 @@ const CookieBar: FunctionComponent = () => {
   return (
     !completed && (
       <div className="sticky -bottom-3 rounded-md border border-tertiary bg-surface px-5 py-3 shadow-md">
-        <p>
-          This website uses cookies to ensure you get the best experience on our
-          website. It&apos;s also a joke so many of the features are buggy or
-          doens&apos;t even work on purpose. You can customize your experience
-          and cookie settings in the settings menu.
-        </p>
-        <div className="flex items-center justify-end gap-3">
+        <p>{t('cookieConsent')}</p>
+        <div className="my-2 flex items-center justify-end gap-3">
           <Link href="/settings" passHref prefetch={false}>
             {t('navigation.settings')}
           </Link>

--- a/src/components/templates/MainLayout.tsx
+++ b/src/components/templates/MainLayout.tsx
@@ -7,6 +7,7 @@ import Header from '@/components/organisms/Header';
 import { ChatBubbleHost } from '@/features/chat_bubble';
 import { DeadPixelHost } from '@/features/dead_pixel';
 import ContainerGiftFlaps from '@/features/gifts/components/ContainerGiftFlaps';
+import { StickyVideoExperienceHost } from '@/features/sticky_video';
 import { WheelOfFortuneHost } from '@/features/wheel_of_fortune';
 import { useExperienceFlagsStore } from '@/state/experience_flags';
 
@@ -32,6 +33,7 @@ const MainLayout: FunctionComponent<MainLayoutProps> = ({
         {deadPixel && <DeadPixelHost />}
         {mockChat && <ChatBubbleHost />}
         <CookieBar />
+        <StickyVideoExperienceHost />
       </div>
     </div>
   );

--- a/src/features/settings/components/ExperienceSettings.tsx
+++ b/src/features/settings/components/ExperienceSettings.tsx
@@ -81,6 +81,14 @@ const ExperienceSettings: FunctionComponent = () => {
         />
       </SettingsBlockRow>
       <SettingsBlockRow
+        label={t('settings:section.experienceFlags.stickyVideo')}>
+        <FormCheckbox
+          name="sticky_video"
+          checked={experience.stickyVideo}
+          onValueChange={experience.setStickyVideo}
+        />
+      </SettingsBlockRow>
+      <SettingsBlockRow
         label={t('settings:section.experienceFlags.wheelOfFortune')}>
         <FormCheckbox
           name="wheel_of_fortune"

--- a/src/features/sticky_video/StickyVideoExperienceHost.tsx
+++ b/src/features/sticky_video/StickyVideoExperienceHost.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useTranslation } from 'next-i18next';
+import { FunctionComponent, useEffect, useRef, useState } from 'react';
+
+import Icon from '@/components/atoms/Icon';
+import { useExperienceFlagsStore } from '@/state/experience_flags';
+import { useUserGrantsStore } from '@/state/user_grants';
+
+const StickyVideoExperienceHost: FunctionComponent = () => {
+  const stickyVideo = useExperienceFlagsStore((state) => state.stickyVideo);
+  const allowed = useUserGrantsStore((state) => state.reviewCompleted);
+  const [mounted, setMounted] = useState(false);
+  const [closed, setClosed] = useState(false);
+  const { t } = useTranslation('common');
+  const $playerRef = useRef<HTMLIFrameElement | null>(null);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!stickyVideo || !mounted || closed || !allowed) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="sticky bottom-2 right-2 flex justify-end md:fixed">
+        <button
+          className="absolute right-2 top-1"
+          aria-label={t('actions.close')}
+          onClick={() => setClosed(true)}>
+          <Icon icon="close" />
+        </button>
+        <iframe
+          className="aspect-video max-h-56 overflow-hidden rounded-lg md:max-h-96"
+          ref={$playerRef}
+          src="https://www.youtube.com/embed/M7lc1UVf-VE?autoplay=1&controls=2&loop=1&mute=1"
+        />
+      </div>
+    </>
+  );
+};
+
+export default StickyVideoExperienceHost;

--- a/src/features/sticky_video/index.ts
+++ b/src/features/sticky_video/index.ts
@@ -1,0 +1,1 @@
+export { default as StickyVideoExperienceHost } from './StickyVideoExperienceHost';

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -28,36 +28,38 @@ const PrivacyPolicy: NextPage = () => {
 };
 
 const contentMarkdownEn = `
-  This Policy describes the information we collect from you, how we use that information and our legal basis for doing so. It also covers whether and how that information may be shared and your rights and choices regarding the information you provide to us. This Privacy Policy applies to the information that we obtain through your use of mostannoyingwebsite.com (The MAW) website.
+  This Policy describes the information we collect from you, how we use that information, and our legal basis for doing so. It also covers whether and how that information may be shared and your rights and choices regarding the information you provide to us. This Privacy Policy applies to the information that we obtain through your use of mostannoyingwebsite.com (The MAW) website.
 
   ### Who we are
 
-  The MAW is an open source project which is publicly available through [our git repository](${config.githubRepo}).
-  If you have any questions about this privacy policy, please contact us at [${config.contactEmail}](${config.contactEmail}) email. We don't sell your personal data to anyone.
+  The MAW is an open-source project that is publicly available through our [Git repository](${config.githubRepo}). If you have any questions about this privacy policy, please contact us at [${config.contactEmail}](${config.contactEmail}). We don't sell your personal data to anyone.
 
   ### What we collect
 
-  In order for us to provide you the best possible experience on our websites, we need to collect and process certain information. Depending on your use of the Services, that may include:
+  To provide you with the best possible experience on our website, we need to collect and process certain information. Depending on your use of the Services, that may include:
 
-  - **Usage data** — when you visit our site, we will store: the website from which you visited us from, the parts of our site you visit, the date and duration of your visit, your anonymised IP address, information from the device (device type, operating system, screen resolution, language, country you are located in, and web browser type) you used during your visit, and more. We process this usage data in Vercel Analytics for statistical purposes, to improve our site and to recognize and stop any misuse.
-  - **Cookies** — we use cookies (small data files transferred onto computers or devices by sites) for record-keeping purposes and to enhance functionality on our site. You may deactivate or restrict the transmission of cookies by changing the settings of your web browser. Cookies that are already stored may be deleted at any time.
-      
+  - **Usage data** — When you visit our site, we will store: the website from which you visited us, the parts of our site you visit, the date and duration of your visit, your anonymized IP address, and information from the device (device type, operating system, screen resolution, language, country, and web browser type) you used during your visit. We process this usage data in Vercel Analytics for statistical purposes, to improve our site, and to recognize and prevent misuse.
+  - **Cookies** — We use cookies (small data files transferred onto computers or devices by sites) for record-keeping purposes and to enhance functionality on our site. You may deactivate or restrict the transmission of cookies by adjusting your web browser settings. Cookies that are already stored may be deleted at any time.
+  - **Embedded YouTube Videos** — Our website may include embedded videos from YouTube, operated by Google Inc. When you view a page with an embedded YouTube video, YouTube may collect and process information about your interaction with the video, including IP address, device information, and browsing details. For more information, please refer to Google's Privacy Policy at https://policies.google.com/privacy.
+
   ### Your Rights
 
-  You have the right to be informed of Personal Data processed by The MAW, a right to rectification/correction, erasure and restriction of processing. You also have the right to ask from us a structured, common and machine-readable format of Personal Data you provided to us. We can only identify you via your email address and we can only adhere to your request and provide information if we have Personal Data about you through you having made contact with us directly and/or you using our site and/or service. To exercise any of the rights mentioned in this Privacy Policy and/or in the event of questions or comments relating to the use of Personal Data you may contact us: [${config.contactEmail}](${config.contactEmail}).
-  In addition, you have the right to lodge a complaint with the data protection authority in your jurisdiction.
+  You have the right to be informed of Personal Data processed by The MAW and have the right to rectification/correction, erasure, and restriction of processing. You also have the right to ask us for a structured, common, and machine-readable format of Personal Data you provided to us. We can only identify you via your email address, and we can only adhere to your request and provide information if we have Personal Data about you through direct contact and/or your use of our site and/or services.
+  
+  To exercise any of the rights mentioned in this Privacy Policy and/or if you have questions or comments relating to the use of Personal Data, please contact us at [${config.contactEmail}](${config.contactEmail}). Additionally, you have the right to lodge a complaint with the data protection authority in your jurisdiction.
 
   ### Third party services we use
 
   When you visit our websites, we use the following third party services which may collect personal data:
 
-  | Recipient                    | Purpose of processing           | Lawful basis        | Data location and security | Personal data collected by the third party | Privacy policy                                  |
-  | ---------------------------- | ------------------------------- | ------------------- | -------------------------- | ------------------------------------------ | ----------------------------------------------- |
-  | [Vercel](https://vercel.com) | To website related static files | Legitimate interest | Worldwide                  | None                                       | [link](https://vercel.com/legal/privacy-policy) |
+  | Recipient                      | Purpose of processing           | Lawful basis        | Data location and security | Personal data collected by the third party | Privacy policy                                  |
+  | ------------------------------ | ------------------------------- | ------------------- | -------------------------- | ------------------------------------------ | ----------------------------------------------- |
+  | [Vercel](https://vercel.com)   | To website related static files | Legitimate interest | Worldwide                  | None                                       | [link](https://vercel.com/legal/privacy-policy) |
+  | [Youtube](https://youtube.com) | Embedded videos                 | Legitimate interest | Worldwide                  | Device and browsing information            | [link](https://policies.google.com/privacy)     |
 
   ### Retention of data
 
-  We will retain your information as long as your account is active, as necessary to provide you with the services or as otherwise set forth in this Policy. We will also retain and use this information as necessary for the purposes set out in this Policy and to the extent necessary to comply with our legal obligations, resolve disputes, enforce our agreements and protect The MAW’s legal rights. We also collect and maintain aggregated, anonymized or pseudonymized information which we may retain indefinitely to protect the safety and security of our Site, improve our Services or comply with legal obligations.
+  We will retain your information as long as necessary to provide you with services or as set forth in this Policy. We will also retain and use this information as necessary for the purposes set out in this Policy and to comply with legal obligations, resolve disputes, enforce agreements, and protect The MAW’s legal rights. We also collect and maintain aggregated, anonymized, or pseudonymized information that we may retain indefinitely to protect the safety and security of our site, improve our Services, or comply with legal obligations.
   
   ### Privacy Policy Changes
 
@@ -66,6 +68,8 @@ const contentMarkdownEn = `
   ### Contact Us
 
   If you have any questions about this Privacy Policy, please contact us at [${config.contactEmail}](${config.contactEmail}).
+
+  Update 2024-10-29: This update includes the necessary notice about embedded YouTube videos and its data-sharing implications, which should help ensure transparency and compliance with privacy laws.
 `;
 
 export const getStaticProps = makeI18nStaticProps();

--- a/src/state/experience_flags.ts
+++ b/src/state/experience_flags.ts
@@ -14,6 +14,7 @@ export interface ExperienceFlagsState {
     randomGlitch: boolean;
   };
   searchDelay: boolean;
+  stickyVideo: boolean;
   wheelOfFortune: boolean;
 }
 
@@ -26,6 +27,7 @@ export interface ExperienceFlagsStateActions {
   setNotifications: (notifications: boolean) => void;
   setPageTitle: (pageTitle: Partial<ExperienceFlagsState['pageTitle']>) => void;
   setSearchDelay: (searchDelay: boolean) => void;
+  setStickyVideo: (stickyVideo: boolean) => void;
   setWheelOfFortune: (wheelOfFortune: boolean) => void;
 }
 
@@ -48,6 +50,7 @@ const initialState: ExperienceFlagsState = {
     inactiveArrayPaged: true,
   },
   searchDelay: true,
+  stickyVideo: true,
   wheelOfFortune: true,
 };
 
@@ -69,17 +72,18 @@ export const useExperienceFlagsStore = create(
           },
         })),
       setSearchDelay: (searchDelay) => set({ searchDelay }),
+      setStickyVideo: (stickyVideo) => set({ stickyVideo }),
       setWheelOfFortune: (wheelOfFortune) => set({ wheelOfFortune }),
     }),
     {
       name: 'zustand-experience-flags-storage',
       storage: createJSONStorage(() => localStorage),
-      version: 5,
+      version: 6,
       migrate: (persistedState, _version) => {
         // Versions are supersets atm
         return {
           ...(persistedState as ExperienceFlagsStore),
-          version: 5,
+          version: 6,
         };
       },
     },


### PR DESCRIPTION
## Description

- Add a random Youtube video to the footer once the user acknowledged cookie info (_might get replace with ours at some point_)
- Update privacy policy

## Checklist

- [ ] I have tested these changes locally.
- [ ] I have reviewed the code changes.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added appropriate test cases, if applicable.
- [ ] I have run the automated tests successfully.

## Screenshots

<img width="396" alt="image" src="https://github.com/user-attachments/assets/4b1e9bb6-55f4-40b0-a7be-9d5089f7cf05">