### PR TITLE
feat(virgin): add a simple URL that disables all experiences

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -12,7 +12,11 @@
       "donateLinkText": "Donation info here"
     },
     "exitPrompt": "I'd reconsider leaving before some bad things happend to you. Are you sure?",
-    "readMoreAt": "Read more at"
+    "readMoreAt": "Read more at",
+    "virgin": {
+      "title": "Disable all experiences",
+      "description": "All experiences are disabled now. If you want share this page just for the content just pass this URL around. If you changed your mind, you can re-enable all experiences in the settings menu."
+    }
   },
   "navigation": {
     "home": "Home",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -51,6 +51,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     commonPageMeta('privacy-policy'),
     commonPageMeta('search'),
     commonPageMeta('settings'),
+    commonPageMeta('virgin'),
     commonPageMeta('user/login'),
     commonPageMeta('user/password-reminder'),
     commonPageMeta('user/registration'),

--- a/src/pages/virgin.tsx
+++ b/src/pages/virgin.tsx
@@ -8,7 +8,7 @@ import { useExperienceFlagsStore } from '@/lib/state/experience_flags';
 import { makeI18nStaticProps } from '@/lib/utils/i18n';
 import styles from '@/styles/content.module.css';
 
-const PrivacyPolicy: NextPage = () => {
+const Virgin: NextPage = () => {
   const { t } = useTranslation('common');
   const allDisabled = useExperienceFlagsStore((state) => state.allDisabled);
 
@@ -30,4 +30,4 @@ const PrivacyPolicy: NextPage = () => {
 };
 
 export const getStaticProps = makeI18nStaticProps();
-export default PrivacyPolicy;
+export default Virgin;

--- a/src/pages/virgin.tsx
+++ b/src/pages/virgin.tsx
@@ -1,0 +1,33 @@
+import { NextPage } from 'next';
+import { useTranslation } from 'next-i18next';
+import { useEffect } from 'react';
+
+import PageHeadline from '@/components/atoms/PageHeadline';
+import SiteTitle from '@/components/atoms/SiteTitle';
+import { useExperienceFlagsStore } from '@/lib/state/experience_flags';
+import { makeI18nStaticProps } from '@/lib/utils/i18n';
+import styles from '@/styles/content.module.css';
+
+const PrivacyPolicy: NextPage = () => {
+  const { t } = useTranslation('common');
+  const allDisabled = useExperienceFlagsStore((state) => state.allDisabled);
+
+  useEffect(() => {
+    allDisabled();
+  }, [allDisabled]);
+
+  return (
+    <main>
+      <SiteTitle>{t('app.virgin.title')}</SiteTitle>
+      <PageHeadline className="mx-auto w-full max-w-screen-md">
+        {t('app.virgin.title')}
+      </PageHeadline>
+      <div className={styles['content']}>
+        <p>{t('app.virgin.description')}</p>
+      </div>
+    </main>
+  );
+};
+
+export const getStaticProps = makeI18nStaticProps();
+export default PrivacyPolicy;


### PR DESCRIPTION
## Description

Add a hidden URL for disabling all the experiences. This is going to be useful when sending this page to someone just because of the content.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation, if necessary.
- [x] I have added appropriate test cases, if applicable.
- [x] I have run the automated tests successfully.
