### PR TITLE
fix: storybook runtime now actually has styles

### DIFF
--- a/apps/ui-docs/.storybook/global.css
+++ b/apps/ui-docs/.storybook/global.css
@@ -1,0 +1,2 @@
+@import "@maw/ui/global.css";
+@source "../node_modules/@maw/ui/src"

--- a/apps/ui-docs/.storybook/main.ts
+++ b/apps/ui-docs/.storybook/main.ts
@@ -30,7 +30,8 @@ const config: StorybookConfig = {
     "../public"
   ],
   stories: [
-    "../node_modules/@maw/ui/src/**/*.stories.{js|jsx|mjs|ts|tsx}",
+    // "./src/**/*.stories.@(js,ts,jsx,tsx)",
+    "../node_modules/@maw/ui/src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
     "../node_modules/@maw/ui/src/**/*.mdx",
   ],
   webpackFinal: async (config) => {

--- a/apps/ui-docs/.storybook/preview.tsx
+++ b/apps/ui-docs/.storybook/preview.tsx
@@ -4,7 +4,7 @@ import {
 } from '@storybook/addon-themes';
 import React from 'react';
 
-import '@maw/ui/global.css';
+import './global.css';
 
 const preview: Preview = {
   parameters: {

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -1,4 +1,4 @@
-import '@maw/ui/global.css';
+import '@/global.css';
 import { Metadata, Viewport } from "next";
 import config from '@/config';
 import { Open_Sans } from 'next/font/google';

--- a/apps/web/src/features/auth/components/CountryField.tsx
+++ b/apps/web/src/features/auth/components/CountryField.tsx
@@ -31,6 +31,7 @@ const CountryField: FunctionComponent<CountryFieldProps> = ({
       <label>
         <h5 className="mb-1">{t('user.field.countryCode')}</h5>
         <DropdownSelect
+          placeholder=""
           className="w-full"
           values={countryOptions}
           {...register('countryCode', {

--- a/apps/web/src/features/auth/components/DateOfBirthField.tsx
+++ b/apps/web/src/features/auth/components/DateOfBirthField.tsx
@@ -62,16 +62,19 @@ const DateOfBirthField: FunctionComponent<DateOfBirthFieldProps> = ({
         <h5 className="mb-1">{t('user.field.dateOfBirth')}</h5>
         <div className="flex gap-3">
           <DropdownSelect
+            placeholder=""
             className="w-1/4"
             values={dateOfBirthYear}
             onValueChange={onYearChange}
           />
           <DropdownSelect
+            placeholder=""
             className="w-2/4"
             values={dateOfBirthMonth}
             onValueChange={onMonthChange}
           />
           <DropdownSelect
+            placeholder=""
             className="w-1/4"
             values={dateOfBirthDay}
             onValueChange={onDayChange}

--- a/apps/web/src/features/auth/components/GenderField.tsx
+++ b/apps/web/src/features/auth/components/GenderField.tsx
@@ -34,6 +34,7 @@ const GenderField: FunctionComponent<GenderFieldProps> = ({
       <label>
         <h5 className="mb-1">{t('user.field.gender')}</h5>
         <DropdownSelect
+          placeholder=""
           values={genderOptions}
           className="w-full"
           {...register('gender')}

--- a/apps/web/src/features/auth/components/PhoneNumberField.tsx
+++ b/apps/web/src/features/auth/components/PhoneNumberField.tsx
@@ -119,6 +119,7 @@ const PhoneNumberField: FunctionComponent<PhoneNumberFieldProps> = ({
         <h5 className="mb-1">{t('user.field.phoneNumber')}</h5>
         <div className="flex gap-3">
           <DropdownSelect
+            placeholder=""
             className="w-1/4"
             values={phoneCountryOptions}
             {...register('phoneNumberCountry', {

--- a/apps/web/src/global.css
+++ b/apps/web/src/global.css
@@ -1,0 +1,4 @@
+@import "@maw/ui/global.css";
+
+@source "../src";
+@source "../node_modules/@maw/ui/src";

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -13,3 +13,18 @@ pnpm i @maw/ui
 ### 2. Installing tailwind
 
 Depending on the usage you might also want to configure Tailwind.
+
+## Troubleshooting
+
+### **Looks like styles are not being applied and you are not even getting errors?**
+
+You probably need to mark the source paths for tailwind static analyzer, you might want to add your intermediate global.css file where you import the one from this package and add source lines below the import. Eventually having something like this:
+
+```css
+@import "@maw/ui/global.css";
+
+@source "../node_modules/@maw/ui/src";
+@source "./";
+```
+
+[Read more](https://tailwindcss.com/docs/detecting-classes-in-source-files)

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,9 +5,10 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./utils": "./src/utils/index.ts",
+    "./components/*": "./src/components/*",
+    "./content.module.css": "./src/styles/content.module.css",
     "./global.css": "./src/styles/global.css",
-    "./content.module.css": "./src/styles/content.module.css"
+    "./utils": "./src/utils/index.ts"
   },
   "scripts": {
     "check-types": "tsc --noEmit",

--- a/packages/ui/src/components/atoms/DropdownSelect.tsx
+++ b/packages/ui/src/components/atoms/DropdownSelect.tsx
@@ -4,7 +4,7 @@ export type DropdownSelectProps = DetailedHTMLProps<
   SelectHTMLAttributes<HTMLSelectElement>,
   HTMLSelectElement
 > & {
-  appendPlaceholder?: boolean;
+  placeholder?: string;
   values: { value: string | number; label: string | number }[];
   onValueChange?: (value?: string) => void;
 };
@@ -12,7 +12,7 @@ export type DropdownSelectProps = DetailedHTMLProps<
 export const DropdownSelect = forwardRef<HTMLSelectElement, DropdownSelectProps>(
   (
     {
-      appendPlaceholder = true,
+      placeholder,
       className,
       values,
       onChange,
@@ -32,7 +32,7 @@ export const DropdownSelect = forwardRef<HTMLSelectElement, DropdownSelectProps>
         className={`rounded-lg border border-primary bg-surface p-2 text-on-surface ${className}`}
         ref={ref}
         {...rest}>
-        {appendPlaceholder && <option value=""></option>}
+        {typeof placeholder !== "undefined" && <option value="">{placeholder}</option>}
         {values.map(({ value, label }) => (
           <option key={`${value}-${label}`} value={value}>
             {label}

--- a/packages/ui/src/styles/global.css
+++ b/packages/ui/src/styles/global.css
@@ -1,4 +1,4 @@
-@import "tailwindcss" source("../../../../");
+@import "tailwindcss";
 @import "./themes/index.css";
 
 html,

--- a/packages/ui/src/utils/form.ts
+++ b/packages/ui/src/utils/form.ts
@@ -36,7 +36,7 @@ export const resolveFormElementSize = (size: FormElementSize) => {
       break;
     case "md":
     default:
-      className = "px-3 py-2 text-md";
+      className = "px-3 py-2 text-base";
       break;
   }
   return className;


### PR DESCRIPTION
## Description

What's really annoying about Tailwind is that it does it's static analysis on the files that are in the source paths and that we are good to go during runtime BUT if some files are not in the source then our components still work like charm however without any runtime styles...

Anyway, this PR reintroduces working runtime styles for storybook.

## Related Issues

Followup for #116 

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [x] I have updated the documentation, if necessary.
- [x] I have added appropriate test cases, if applicable.
- [x] I have run the automated tests successfully.
